### PR TITLE
fix to retrieve the correct TestSet to Execute

### DIFF
--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -418,7 +418,7 @@ namespace HpToolsLauncher
             ITestSet targetTestSet = null;
             foreach (ITestSet ts in tsList)
             {
-                if (ts.Name.Equals(tsName, StringComparison.InvariantCultureIgnoreCase))
+                if (ts.Name.Equals(tsName, StringComparison.InvariantCultureIgnoreCase) && (ts.TestSetFolder.NodeID == tsFolder.NodeID))
                 {
                     targetTestSet = ts;
                     break;


### PR DESCRIPTION
Using FindTestSet method it retrieve the TestSetList of all the subfolders. So if you have more testset under different subfolders from a giving path with the same name the plugin should run the wrong testset. So I added the condition (at line 421) that the nodeID of the parent folder must be the same of the last folder of the given path.


Please Make sure these boxes are checked before submitting your pull request - Thanks ahead!

- [x ] Proper pull request title - concise and clear for others.
- [x ] Proper pull request short description - clear and concise (as it should appear in the Jira ticket) for other developers and users.
- [ ] Proper Jira ticket - Number, Link in pull request description.
- [ ] The PR can is merged on your machine without any conflicts.
- [ ] The PR can is built on your machine without any (new) warnings.
- [ ] The PR passed sanity tests by you / QA / DevTest / Good Samaritain.
- [ ] Add unit tests with new features.
- [ ] If you added any dependency to the POM - Please update @YafimK
